### PR TITLE
Install lua and luarocks to allow use of other modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,7 @@ RUN apt-get update && \
 
 RUN curl -s https://packagecloud.io/install/repositories/akopytov/sysbench/script.deb.sh | bash
 
-RUN apt-get -y install sysbench && \
+RUN apt-get -y install sysbench git make gcc unzip wget lua5.1 lua5.1-dev && \
         apt-get clean
+
+RUN wget https://luarocks.org/releases/luarocks-2.4.3.tar.gz && tar zxpf luarocks-2.4.3.tar.gz && cd luarocks-2.4.3 && ./configure && make bootstrap


### PR DESCRIPTION
This PR installs lua, luarocks, and its dependencies so that additional modules can be used to benchmark other databases beyond those supported out of the box by sysbench (for example lua-cassandra or mongorover).